### PR TITLE
feat: 各ユーザーが通知日数を設定できる機能を追加

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -11,6 +11,7 @@ import Events from './pages/Events';
 import Tests from './pages/Tests';
 import Login from './pages/Login';
 import Signup from './pages/Signup';
+import Setting from './pages/Setting';
 
 import { Session } from '@supabase/supabase-js';
 import { Loader2 } from 'lucide-react';
@@ -75,6 +76,7 @@ function App() {
                   <Route path="tasks" element={<Tasks />} />
                   <Route path="events" element={<Events />} />
                   <Route path="tests" element={<Tests />} />
+                  <Route path="setting" element={<Setting />} />
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
               </Layout>

--- a/src/app/_components/Navbar.tsx
+++ b/src/app/_components/Navbar.tsx
@@ -92,9 +92,11 @@ const Navbar: React.FC = () => {
             {session ? (
               <div className="ml-4 flex items-center">
                 <div className="flex items-center space-x-2 border-l pl-4 border-gray-200">
-                  <div className="h-8 w-8 rounded-full bg-blue-600 flex items-center justify-center text-white font-medium">
-                    {userInitial}
-                  </div>
+                  <Link to="/setting">
+                    <div className="h-8 w-8 rounded-full bg-blue-600 flex items-center justify-center text-white font-medium cursor-pointer hover:opacity-80">
+                      {userInitial}
+                    </div>
+                  </Link>
                   <button
                     onClick={handleSignOut}
                     className="flex items-center text-gray-700 hover:text-red-500 transition-colors duration-200"
@@ -151,9 +153,11 @@ const Navbar: React.FC = () => {
           {session ? (
             <div className="pt-4 pb-3 border-t border-gray-200">
               <div className="flex items-center px-3">
-                <div className="h-10 w-10 rounded-full bg-blue-600 flex items-center justify-center text-white font-medium">
-                  {userInitial}
-                </div>
+                <Link to="/setting" onClick={() => setIsOpen(false)}>
+                  <div className="h-10 w-10 rounded-full bg-blue-600 flex items-center justify-center text-white font-medium cursor-pointer hover:opacity-80">
+                    {userInitial}
+                  </div>
+                </Link>
                 <div className="ml-3">
                   <div className="text-sm font-medium text-gray-800">
                     {session.user?.email}

--- a/src/app/pages/Setting.tsx
+++ b/src/app/pages/Setting.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { useState, useEffect } from "react";
+import { supabase } from "../supabaseClient";
+import Button from "../_components/Button";
+
+export default function NotificationSettingPage() {
+  const [notificationDays, setNotificationDays] = useState<number>(1);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  useEffect(() => {
+    // ユーザー情報取得（例: ログインユーザーのID取得）
+    const fetchData = async () => {
+      setLoading(true);
+      setError(null);
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+      if (userError || !user) {
+        setError("ユーザー情報の取得に失敗しました");
+        setLoading(false);
+        return;
+      }
+      // notification_days取得
+      const { data, error: dbError } = await supabase
+        .from("users")
+        .select("notification_days")
+        .eq("id", user.id)
+        .single();
+      if (dbError || !data) {
+        setError("通知日数の取得に失敗しました");
+      } else {
+        setNotificationDays(data.notification_days ?? 1);
+      }
+      setLoading(false);
+    };
+    fetchData();
+  }, []);
+
+  const handleSave = async () => {
+  setSaving(true);
+  setError(null);
+  setSuccess(null);
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+    if (userError || !user) {
+      setError("ユーザー情報の取得に失敗しました");
+      setSaving(false);
+      return;
+    }
+    const { error: dbError } = await supabase
+      .from("users")
+      .update({ notification_days: notificationDays })
+      .eq("id", user.id);
+    if (dbError) {
+      setError("通知日数の更新に失敗しました");
+    } else {
+      setSuccess("更新完了しました");
+    }
+    setSaving(false);
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-10 p-6 bg-white rounded shadow">
+      <h1 className="text-xl font-bold mb-4">通知日数の設定</h1>
+      {loading ? (
+        <p>読み込み中...</p>
+      ) : (
+        <>
+          <label className="block mb-2 font-medium">通知日数（1～30日）</label>
+          <input
+            type="number"
+            min={1}
+            max={30}
+            value={notificationDays}
+            onChange={e => {
+              const val = Math.max(1, Math.min(30, Number(e.target.value)));
+              setNotificationDays(val);
+            }}
+            className="border rounded px-2 py-1 w-full mb-4"
+          />
+          <Button
+            onClick={handleSave}
+            disabled={saving}
+            variant="primary"
+            size="md"
+          >
+            {saving ? "保存中..." : "保存"}
+          </Button>
+          {error && <p className="text-red-500 mt-2">{error}</p>}
+          {success && <p className="text-green-600 mt-2">{success}</p>}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -1,0 +1,6 @@
+"use client";
+import App from '../App';
+
+export default function Page() {
+  return <App />;
+}


### PR DESCRIPTION
## 機能
- `users` テーブルに `notify_after_days` カラムを追加
- ログイン後、ユーザーアイコンから通知日数設定画面に遷移可能
- 通知日数は 1〜30 日の範囲で設定可能

## 検証
- 通知日数が正常に更新されることを確認済み

## 確認事項
- UI はこのままで問題ないでしょうか？